### PR TITLE
Multiple executions of `makeModules` produce invalid `module.xml` file

### DIFF
--- a/src/main/groovy/com/github/zhurlik/extension/JBossModule.groovy
+++ b/src/main/groovy/com/github/zhurlik/extension/JBossModule.groovy
@@ -154,7 +154,8 @@ class JBossModule {
             def originalVer = this.ver
             this.ver = server.version
 
-            def xmlfile = new File(moduleDir, 'module.xml') << getModuleDescriptor()
+            def xmlfile = new File(moduleDir, 'module.xml')
+            xmlfile.text = getModuleDescriptor()
             log.debug '>> Module Descriptor:' + xmlfile.path
 
             // revert version


### PR DESCRIPTION
see https://github.com/martoe/gradle-jboss-modules-plugin/issues/2
