### PR TITLE
Add support for specifying configuration for modules and incremental build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,17 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    hibernate43
+    hibernate50
+}
+
 dependencies {
     ['aop', 'beans', 'core', 'context'].each {
         jbossmodules "org.springframework:spring-${it}:${springVersion}"
     }
+    hibernate43 'org.hibernate:hibernate-core:4.3.11.Final'
+    hibernate50 'org.hibernate:hibernate-core:5.0.6.Final'
 }
 
 jbossrepos {
@@ -64,7 +71,21 @@ modules {
         ]
     }
     // springframework
-
+    
+    // specify multiple versions of the same module
+    hibernate43 {
+        moduleName 'org.hibernate.core'
+        resources = ["hibernate-core-4.3.11.Final.jar"]
+        slot = '4.3.11'
+        configuration = configurations.hibernate43
+    }
+      
+    hibernate50 {
+        moduleName 'org.hibernate.core'
+        resources = ["hibernate-core-5.0.6.Final.jar"]
+        slot = '5.0.6'
+        configuration = configurations.hibernate50
+    }
 
     moduleA {
         // to define on which servers this module will be available, by default - all

--- a/src/main/groovy/com/github/zhurlik/JBossModulesPlugin.groovy
+++ b/src/main/groovy/com/github/zhurlik/JBossModulesPlugin.groovy
@@ -60,9 +60,13 @@ class JBossModulesPlugin implements Plugin<Project> {
         }
 
         // special tasks
-        project.task('makeModules', type: MakeModulesTask)
-        project.task('checkModules', type: CheckModulesTask)
-        project.task('deployModules', type: DeployModulesTask)
+        def makeModulesTask = project.task('makeModules', type: MakeModulesTask)
+        project.task('checkModules', type: CheckModulesTask) {
+            outputs.upToDateWhen {
+                !makeModulesTask.didWork
+            }
+        }
+        def deployModulesTask = project.task('deployModules', type: DeployModulesTask)
         project.tasks.checkModules.dependsOn('makeModules')
         project.tasks.deployModules.dependsOn('checkModules')
     }

--- a/src/main/groovy/com/github/zhurlik/JBossModulesPlugin.groovy
+++ b/src/main/groovy/com/github/zhurlik/JBossModulesPlugin.groovy
@@ -66,7 +66,7 @@ class JBossModulesPlugin implements Plugin<Project> {
                 !makeModulesTask.didWork
             }
         }
-        def deployModulesTask = project.task('deployModules', type: DeployModulesTask)
+        project.task('deployModules', type: DeployModulesTask)
         project.tasks.checkModules.dependsOn('makeModules')
         project.tasks.deployModules.dependsOn('checkModules')
     }

--- a/src/main/groovy/com/github/zhurlik/task/CheckModulesTask.groovy
+++ b/src/main/groovy/com/github/zhurlik/task/CheckModulesTask.groovy
@@ -3,7 +3,6 @@ package com.github.zhurlik.task
 import com.github.zhurlik.extension.JBossModule
 import groovy.util.logging.Slf4j
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 
 import static java.io.File.separator

--- a/src/main/groovy/com/github/zhurlik/task/CheckModulesTask.groovy
+++ b/src/main/groovy/com/github/zhurlik/task/CheckModulesTask.groovy
@@ -3,6 +3,7 @@ package com.github.zhurlik.task
 import com.github.zhurlik.extension.JBossModule
 import groovy.util.logging.Slf4j
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 
 import static java.io.File.separator

--- a/src/main/groovy/com/github/zhurlik/task/DeployModulesTask.groovy
+++ b/src/main/groovy/com/github/zhurlik/task/DeployModulesTask.groovy
@@ -4,6 +4,8 @@ import com.github.zhurlik.extension.JBossModule
 import com.github.zhurlik.extension.JBossServer
 import groovy.util.logging.Slf4j
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.TaskAction
 
 /**
@@ -13,13 +15,24 @@ import org.gradle.api.tasks.TaskAction
  */
 @Slf4j('logger')
 class DeployModulesTask extends DefaultTask {
+    @InputDirectory
+    File inputDir = project.file("$project.buildDir/install")
+
     @TaskAction
     def deployModules() {
         logger.info ">> Deploying Modules to JBoss Servers..."
+
+        project.delete deployDirectories
+
         project.modules.each() { JBossModule m ->
             project.jbossrepos.each { JBossServer s ->
                 m.deployToJBoss(s, project)
             }
         }
+    }
+
+    @OutputDirectories
+    def getDeployDirectories() {
+        project.jbossrepos.collect { new File(it.home.toString()) }
     }
 }

--- a/src/main/groovy/com/github/zhurlik/task/MakeModulesTask.groovy
+++ b/src/main/groovy/com/github/zhurlik/task/MakeModulesTask.groovy
@@ -2,6 +2,7 @@ package com.github.zhurlik.task
 import com.github.zhurlik.extension.JBossModule
 import groovy.util.logging.Slf4j
 import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskExecutionException
 /**
@@ -19,7 +20,7 @@ class MakeModulesTask extends DefaultTask {
         logger.info ">> Creating JBoss Modules locally..."
 
         if (project.jbossrepos.isEmpty()) {
-            throw new TaskExecutionException('You need at least one JBoss Server');
+            throw new GradleException('You need at least one JBoss Server');
         }
 
         project.modules.each() { JBossModule m ->

--- a/src/main/groovy/com/github/zhurlik/task/MakeModulesTask.groovy
+++ b/src/main/groovy/com/github/zhurlik/task/MakeModulesTask.groovy
@@ -2,9 +2,17 @@ package com.github.zhurlik.task
 import com.github.zhurlik.extension.JBossModule
 import groovy.util.logging.Slf4j
 import org.gradle.api.DefaultTask
+import org.gradle.api.DomainObjectCollection
 import org.gradle.api.GradleException
+import org.gradle.api.file.FileCollection
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskExecutionException
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs
+
 /**
  * The main task to create folder structure for JBoss Modules like this
  *
@@ -15,9 +23,14 @@ import org.gradle.api.tasks.TaskExecutionException
  */
 @Slf4j('logger')
 class MakeModulesTask extends DefaultTask {
+    @OutputDirectory
+    File installDir = project.file("$project.buildDir/install")
+
     @TaskAction
     def makeModules() {
         logger.info ">> Creating JBoss Modules locally..."
+
+        project.delete installDir
 
         if (project.jbossrepos.isEmpty()) {
             throw new GradleException('You need at least one JBoss Server');
@@ -26,5 +39,22 @@ class MakeModulesTask extends DefaultTask {
         project.modules.each() { JBossModule m ->
             m.makeLocally(project)
         }
+    }
+
+    @Input
+    private Collection<String> getModuleDescriptions() {
+        project.modules.collect { it.moduleDescriptor }
+    }
+
+    @InputFiles
+    private FileCollection getModuleResources() {
+        def resources = project.configurations.jbossmodules
+        project.modules.each { JBossModule module ->
+            if (module.configuration != null) {
+                resources += module.configuration
+            }
+        }
+
+        return resources
     }
 }


### PR DESCRIPTION
This PR adds a couple of things:

Incremental build support: The make and deploy task have been made incremental. That is, they will be flagged as UP-TO-DATE when no work is to be done. Changes to the module definition or input configuration (incoming dependencies) will trigger to the tasks to run again. Also, the check task will only run when the make task runs.

Per-module configurations: This is mainly to support multi-version modules. As it is, since artifacts are fetched from a single configuration 'jbossmodules' there is no way to have multiple versions of the same dependency, as Gradle will use conflict resolution to pick one or the other. The only way to have multiple versions of the same dependency is using multiple configurations. This PR allows one to specify the configuration used to locate module resources via a 'configuration' property on the module.
