### PR TITLE
fix flaky tests

### DIFF
--- a/src/test/groovy/TestUtils/XMLUtil.groovy
+++ b/src/test/groovy/TestUtils/XMLUtil.groovy
@@ -1,12 +1,16 @@
-package com.github.zhurlik.descriptor
+package TestUtils
 
 import static org.junit.Assert.assertEquals
 
 class XMLUtil {
 
     static void assertXMLStrings(String expectedString, String actualString) {
+        assertXMLStrings(null, expectedString, actualString)
+    }
+
+    static void assertXMLStrings(String message, String expectedString, String actualString) {
         def expected = new XmlSlurper().parseText(expectedString)
         def actual = new XmlSlurper().parseText(actualString)
-        assertEquals expected, actual
+        assertEquals(message, expected, actual)
     }
 }

--- a/src/test/groovy/TestUtils/XMLUtil.groovy
+++ b/src/test/groovy/TestUtils/XMLUtil.groovy
@@ -2,12 +2,21 @@ package TestUtils
 
 import static org.junit.Assert.assertEquals
 
+/**
+ * Provides specific asserts to compare XML strings.
+ */
 class XMLUtil {
 
     static void assertXMLStrings(String expectedString, String actualString) {
         assertXMLStrings(null, expectedString, actualString)
     }
 
+    /**
+     * Parses and compares two XML strings.
+     * @param message to print when assertion fails
+     * @param expectedString expected XML string
+     * @param actualString actual XML string
+     */
     static void assertXMLStrings(String message, String expectedString, String actualString) {
         def expected = new XmlSlurper().parseText(expectedString)
         def actual = new XmlSlurper().parseText(actualString)

--- a/src/test/groovy/com/github/zhurlik/descriptor/XMLUtil.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/XMLUtil.groovy
@@ -1,0 +1,12 @@
+package com.github.zhurlik.descriptor
+
+import static org.junit.Assert.assertEquals
+
+class XMLUtil {
+
+    static void assertXMLStrings(String expectedString, String actualString) {
+        def expected = new XmlSlurper().parseText(expectedString)
+        def actual = new XmlSlurper().parseText(actualString)
+        assertEquals expected, actual
+    }
+}

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_0Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_0Test.groovy
@@ -31,7 +31,7 @@ class Xsd1_0Test {
         module = new JBossModule('test')
         module.moduleName = 'test.module'
         module.ver = V_1_0
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.0' name='test.module' />", V_1_0.getXmlDescriptor(module)
         assertEquals 'modules/test/module/main', V_1_0.getModulePath(module).toString()
 
@@ -40,7 +40,7 @@ class Xsd1_0Test {
         module.moduleConfiguration = true
         module.defaultLoader = 'test_loader1'
         module.ver = V_1_0
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<configuration xmlns='urn:jboss:module:1.0' default-loader='test_loader1'>\n" +
                 "  <loader name='test_loader1' />\n" +
                 "</configuration>", V_1_0.getXmlDescriptor(module)

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_0Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_0Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_1Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_1Test.groovy
@@ -30,7 +30,7 @@ class Xsd1_1Test {
         def module = new JBossModule('test')
         module.moduleName = 'test.module'
         module.ver = V_1_1
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.1' name='test.module' />", V_1_1.getXmlDescriptor(module)
         assertEquals 'modules/test/module/main', V_1_1.getModulePath(module).toString()
 
@@ -39,7 +39,7 @@ class Xsd1_1Test {
         module.moduleName = 'test.module'
         module.moduleAlias = true
         module.targetName = 'target.name'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-alias xmlns='urn:jboss:module:1.1' name='test.module' target-name='target.name' />", V_1_1.getXmlDescriptor(module)
         assertEquals 'modules/test/module/main', V_1_1.getModulePath(module).toString()
 
@@ -48,7 +48,7 @@ class Xsd1_1Test {
         module.moduleConfiguration = true
         module.defaultLoader = 'test_loader1'
         module.ver = V_1_1
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<configuration xmlns='urn:jboss:module:1.1' default-loader='test_loader1'>\n" +
                 "  <loader name='test_loader1' />\n" +
                 "</configuration>", V_1_1.getXmlDescriptor(module)

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_1Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_1Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_2Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_2Test.groovy
@@ -32,7 +32,7 @@ class Xsd1_2Test {
         module = new JBossModule('test')
         module.ver = V_1_2
         module.moduleName = 'test.module'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.2' name='test.module' />", V_1_2.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_2.getModulePath(module).toString()
 
@@ -41,7 +41,7 @@ class Xsd1_2Test {
         module.moduleName = 'test.module'
         module.moduleAlias = true
         module.targetName = 'target.name'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-alias xmlns='urn:jboss:module:1.2' name='test.module' target-name='target.name' />", V_1_2.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_2.getModulePath(module).toString()
 
@@ -49,7 +49,7 @@ class Xsd1_2Test {
         module.ver = V_1_2
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.2' name='test.module' />", V_1_2.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_2.getModulePath(module).toString()
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_2Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_2Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_3Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_3Test.groovy
@@ -32,7 +32,7 @@ class Xsd1_3Test {
         module = new JBossModule('test')
         module.ver = V_1_3
         module.moduleName = 'test.module'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.3' name='test.module' />", V_1_3.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_3.getModulePath(module).toString()
 
@@ -41,7 +41,7 @@ class Xsd1_3Test {
         module.moduleName = 'test.module'
         module.moduleAlias = true
         module.targetName = 'target.name'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-alias xmlns='urn:jboss:module:1.3' name='test.module' target-name='target.name' />", V_1_3.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_3.getModulePath(module).toString()
 
@@ -49,7 +49,7 @@ class Xsd1_3Test {
         module.ver = V_1_3
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.3' name='test.module' />", V_1_3.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_3.getModulePath(module).toString()
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_3Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_3Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_5Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_5Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_5Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_5Test.groovy
@@ -32,7 +32,7 @@ class Xsd1_5Test {
         module = new JBossModule('test')
         module.ver = V_1_5
         module.moduleName = 'test.module'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.5' name='test.module' />", V_1_5.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_5.getModulePath(module).toString()
 
@@ -41,7 +41,7 @@ class Xsd1_5Test {
         module.moduleName = 'test.module'
         module.moduleAlias = true
         module.targetName = 'target.name'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-alias xmlns='urn:jboss:module:1.5' name='test.module' target-name='target.name' />", V_1_5.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_5.getModulePath(module).toString()
 
@@ -49,7 +49,7 @@ class Xsd1_5Test {
         module.ver = V_1_5
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.5' name='test.module' />", V_1_5.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_5.getModulePath(module).toString()
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_6Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_6Test.groovy
@@ -33,7 +33,7 @@ class Xsd1_6Test {
         module.ver = V_1_6
         module.moduleName = 'test.module'
         module.version =  '123-456.789'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.6' name='test.module' version='123-456.789' />", V_1_6.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_6.getModulePath(module).toString()
 
@@ -42,7 +42,7 @@ class Xsd1_6Test {
         module.moduleName = 'test.module'
         module.moduleAlias = true
         module.targetName = 'target.name'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-alias xmlns='urn:jboss:module:1.6' name='test.module' target-name='target.name' />", V_1_6.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_6.getModulePath(module).toString()
 
@@ -50,7 +50,7 @@ class Xsd1_6Test {
         module.ver = V_1_6
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.6' name='test.module' />", V_1_6.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_6.getModulePath(module).toString()
 
@@ -58,7 +58,7 @@ class Xsd1_6Test {
         module.ver = V_1_6
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.6' name='test.module' />", V_1_6.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_6.getModulePath(module).toString()
     }

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_6Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_6Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_7Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_7Test.groovy
@@ -35,7 +35,7 @@ class Xsd1_7Test {
         module.slot = 'deprecated'
         module.moduleName = 'test.module'
         module.version =  '123-456.789'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.7' name='test.module' version='123-456.789' />", V_1_7.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/123-456.789', V_1_7.getModulePath(module).toString()
 
@@ -44,7 +44,7 @@ class Xsd1_7Test {
         module.moduleName = 'test.module'
         module.moduleAlias = true
         module.targetName = 'target.name'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-alias xmlns='urn:jboss:module:1.7' name='test.module' target-name='target.name' />", V_1_7.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_7.getModulePath(module).toString()
 
@@ -52,7 +52,7 @@ class Xsd1_7Test {
         module.ver = V_1_7
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.7' name='test.module' />", V_1_7.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_7.getModulePath(module).toString()
 
@@ -60,7 +60,7 @@ class Xsd1_7Test {
         module.ver = V_1_7
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.7' name='test.module' />", V_1_7.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_7.getModulePath(module).toString()
     }

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_7Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_7Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_8Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_8Test.groovy
@@ -35,7 +35,7 @@ class Xsd1_8Test {
         module.slot = 'deprecated'
         module.moduleName = 'test.module'
         module.version =  '123-456.789'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.8' name='test.module' version='123-456.789' />", V_1_8.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/123-456.789', V_1_8.getModulePath(module).toString()
 
@@ -44,7 +44,7 @@ class Xsd1_8Test {
         module.moduleName = 'test.module'
         module.moduleAlias = true
         module.targetName = 'target.name'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-alias xmlns='urn:jboss:module:1.8' name='test.module' target-name='target.name' />", V_1_8.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_8.getModulePath(module).toString()
 
@@ -52,7 +52,7 @@ class Xsd1_8Test {
         module.ver = V_1_8
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.8' name='test.module' />", V_1_8.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_8.getModulePath(module).toString()
 
@@ -60,7 +60,7 @@ class Xsd1_8Test {
         module.ver = V_1_8
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.8' name='test.module' />", V_1_8.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_8.getModulePath(module).toString()
     }

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_8Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_8Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_9Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_9Test.groovy
@@ -35,7 +35,7 @@ class Xsd1_9Test {
         module.slot = 'deprecated'
         module.moduleName = 'test.module'
         module.version = '123-456.789'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.9' name='test.module' version='123-456.789' />", V_1_9.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/123-456.789', V_1_9.getModulePath(module).toString()
 
@@ -44,7 +44,7 @@ class Xsd1_9Test {
         module.moduleName = 'test.module'
         module.moduleAlias = true
         module.targetName = 'target.name'
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-alias xmlns='urn:jboss:module:1.9' name='test.module' target-name='target.name' />", V_1_9.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_9.getModulePath(module).toString()
 
@@ -52,7 +52,7 @@ class Xsd1_9Test {
         module.ver = V_1_9
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.9' name='test.module' />", V_1_9.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_9.getModulePath(module).toString()
 
@@ -60,7 +60,7 @@ class Xsd1_9Test {
         module.ver = V_1_9
         module.moduleName = 'test.module'
         module.moduleAbsent = true
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module-absent xmlns='urn:jboss:module:1.9' name='test.module' />", V_1_9.getXmlDescriptor(module)
         assertEquals 'modules/system/layers/base/test/module/main', V_1_9.getModulePath(module).toString()
     }

--- a/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_9Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_9Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.descriptor
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import org.junit.Test
 

--- a/src/test/groovy/com/github/zhurlik/extension/BasicJBossModuleTest.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/BasicJBossModuleTest.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -100,9 +101,9 @@ abstract class BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 2
         module = new JBossModule('testModule')
@@ -130,9 +131,9 @@ abstract class BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
     }
 
@@ -158,9 +159,9 @@ abstract class BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 2
         module = new JBossModule('testModule1')
@@ -183,9 +184,9 @@ abstract class BasicJBossModuleTest {
                 "    <exclude path='not this' />\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Test
@@ -209,9 +210,9 @@ abstract class BasicJBossModuleTest {
                 "    <grant actions='test-actions' name='test-name' permission='permission2' />\n" +
                 "  </permissions>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
 
@@ -334,7 +335,7 @@ abstract class BasicJBossModuleTest {
 
         assertTrue new File(getClass().getClassLoader().getResource('projectTest/build/install/testServer/modules/' + prefix + 'org/apache/log4j/main/log4j-1.2.17.jar').toURI().path).exists()
         assertTrue new File(getClass().getClassLoader().getResource('projectTest/build/install/testServer/modules/' + prefix + 'org/apache/log4j/main/module.xml').toURI().path).exists()
-        assertEquals 'Module Descriptor:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Module Descriptor:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.apache.log4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='.' />\n" +
@@ -372,7 +373,7 @@ abstract class BasicJBossModuleTest {
                 "    <system />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue !module.valid
 
         // 2
@@ -464,9 +465,9 @@ abstract class BasicJBossModuleTest {
                 "    </system>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     abstract protected Ver getVersion()

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_0Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_0Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -38,9 +39,9 @@ class JBossModule1_0Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' slot='1.0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -59,9 +60,9 @@ class JBossModule1_0Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 2
         module = new JBossModule('spring-core')
@@ -82,9 +83,9 @@ class JBossModule1_0Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -95,9 +96,9 @@ class JBossModule1_0Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4 properties will be skipped
         module = new JBossModule('test-module-4')
@@ -106,9 +107,9 @@ class JBossModule1_0Test extends BasicJBossModuleTest {
         module.properties = [prop1: 'value1', prop2: 'value2', '': '']
         xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.4' />"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -131,9 +132,9 @@ class JBossModule1_0Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -163,9 +164,9 @@ class JBossModule1_0Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -252,7 +253,7 @@ class JBossModule1_0Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.1' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_1Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_1Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -32,9 +33,9 @@ class JBossModule1_1Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' slot='1.0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -53,9 +54,9 @@ class JBossModule1_1Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 2
         module = new JBossModule('spring-core')
@@ -76,9 +77,9 @@ class JBossModule1_1Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -89,9 +90,9 @@ class JBossModule1_1Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4
         module = new JBossModule('test-module-4')
@@ -105,9 +106,9 @@ class JBossModule1_1Test extends BasicJBossModuleTest {
                 "    <property name='prop2' value='value2' />\n" +
                 "  </properties>\n" +
                 "</module>"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -130,9 +131,9 @@ class JBossModule1_1Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -162,9 +163,9 @@ class JBossModule1_1Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -250,7 +251,7 @@ class JBossModule1_1Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_2Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_2Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -40,9 +41,9 @@ class JBossModule1_2Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' slot='1.0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -61,9 +62,9 @@ class JBossModule1_2Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
 
         // 2
@@ -85,9 +86,9 @@ class JBossModule1_2Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -98,9 +99,9 @@ class JBossModule1_2Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4
         module = new JBossModule('test-module-4')
@@ -114,9 +115,9 @@ class JBossModule1_2Test extends BasicJBossModuleTest {
                 "    <property name='prop2' value='value2' />\n" +
                 "  </properties>\n" +
                 "</module>"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -139,9 +140,9 @@ class JBossModule1_2Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -171,9 +172,9 @@ class JBossModule1_2Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -261,7 +262,7 @@ class JBossModule1_2Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_3Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_3Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -39,9 +40,9 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' slot='1.0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -60,9 +61,9 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
 
         // 2
@@ -84,9 +85,9 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -97,9 +98,9 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4
         module = new JBossModule('test-module-4')
@@ -113,9 +114,9 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
                 "    <property name='prop2' value='value2' />\n" +
                 "  </properties>\n" +
                 "</module>"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -138,9 +139,9 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -170,9 +171,9 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -210,9 +211,9 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
                 "    <native-artifact name='group:module:1.1' />\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Test
@@ -283,7 +284,7 @@ class JBossModule1_3Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_5Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_5Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -39,9 +40,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' slot='1.0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -60,9 +61,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
 
         // 2
@@ -84,9 +85,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -97,9 +98,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4
         module = new JBossModule('test-module-4')
@@ -113,9 +114,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "    <property name='prop2' value='value2' />\n" +
                 "  </properties>\n" +
                 "</module>"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -138,9 +139,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -170,9 +171,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -210,9 +211,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "    <native-artifact name='group:module:1.1' />\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //2
         module = new JBossModule('testModule-2')
@@ -255,9 +256,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //3
         module = new JBossModule('testModule-3')
@@ -291,9 +292,9 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Test
@@ -364,7 +365,7 @@ class JBossModule1_5Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_6Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_6Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -39,9 +40,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' slot='1.0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.0
         module = new JBossModule('testModule')
@@ -52,9 +53,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
         module.version = '1-0'
         xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' slot='1.0' version='1-0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -73,9 +74,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 2
         module = new JBossModule('spring-core')
@@ -96,9 +97,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -109,9 +110,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4
         module = new JBossModule('test-module-4')
@@ -125,9 +126,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
                 "    <property name='prop2' value='value2' />\n" +
                 "  </properties>\n" +
                 "</module>"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -150,9 +151,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -183,9 +184,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -223,9 +224,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
                 "    <native-artifact name='group:module:1.1' />\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //2
         module = new JBossModule('testModule-2')
@@ -279,9 +280,9 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
     }
 
@@ -353,7 +354,7 @@ class JBossModule1_6Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_7Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_7Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -39,9 +40,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.0
         module = new JBossModule('testModule')
@@ -52,9 +53,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
         module.version = '1-0'
         xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' version='1-0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -73,9 +74,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 2
         module = new JBossModule('spring-core')
@@ -96,9 +97,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -109,9 +110,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4
         module = new JBossModule('test-module-4')
@@ -125,9 +126,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "    <property name='prop2' value='value2' />\n" +
                 "  </properties>\n" +
                 "</module>"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -150,9 +151,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -183,9 +184,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -223,9 +224,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "    <native-artifact name='group:module:1.1' />\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //2
         module = new JBossModule('testModule-2')
@@ -279,9 +280,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //3
         module = new JBossModule('testModule-3')
@@ -366,9 +367,9 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Test
@@ -439,7 +440,7 @@ class JBossModule1_7Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_8Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_8Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -39,9 +40,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.0
         module = new JBossModule('testModule')
@@ -52,9 +53,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
         module.version = '1-0'
         xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' version='1-0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -73,9 +74,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 2
         module = new JBossModule('spring-core')
@@ -96,9 +97,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -109,9 +110,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4
         module = new JBossModule('test-module-4')
@@ -125,9 +126,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    <property name='prop2' value='value2' />\n" +
                 "  </properties>\n" +
                 "</module>"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -150,9 +151,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -183,9 +184,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -223,9 +224,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    <native-artifact name='group:module:1.1' />\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //2
         module = new JBossModule('testModule-2')
@@ -279,9 +280,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //3
         module = new JBossModule('testModule-3')
@@ -366,9 +367,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Test
@@ -439,7 +440,7 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +
@@ -461,7 +462,7 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module'>\n" +
                 "  <dependencies />\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
 
         // 2
@@ -523,9 +524,9 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Test
@@ -555,7 +556,7 @@ class JBossModule1_8Test extends BasicJBossModuleTest {
                 "</module>"
         //assertEquals 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Override

--- a/src/test/groovy/com/github/zhurlik/extension/JBossModule1_9Test.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossModule1_9Test.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.Ver
 import groovy.util.logging.Slf4j
 import org.gradle.api.Project
@@ -39,9 +40,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
         module.slot = '1.0'
         String xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.0
         module = new JBossModule('testModule')
@@ -52,9 +53,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
         module.version = '1-0'
         xml = "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module' version='1-0' />"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 1.1
         module = new JBossModule('testModule')
@@ -73,9 +74,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    </exclude-set>\n" +
                 "  </exports>\n" +
                 "</module>"
-        assertEquals 'Case1.1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1.1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 2
         module = new JBossModule('spring-core')
@@ -96,9 +97,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    <module name='org.jboss.vfs' />\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 3
         module = new JBossModule('test-module-3')
@@ -109,9 +110,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.3'>\n" +
                 "  <main-class name='test.MainClass' />\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 4
         module = new JBossModule('test-module-4')
@@ -125,9 +126,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    <property name='prop2' value='value2' />\n" +
                 "  </properties>\n" +
                 "</module>"
-        assertEquals 'Case4:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case4:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 5
         module = new JBossModule('test-module-5')
@@ -150,9 +151,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    </resource-root>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case5:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case5:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         // 6
         module = new JBossModule('test-module-6')
@@ -183,9 +184,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case6:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case6:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings 'Reverse:', "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='test.module.6'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='module1' />\n" +
@@ -223,9 +224,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    <native-artifact name='group:module:1.1' />\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //2
         module = new JBossModule('testModule-2')
@@ -279,9 +280,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
 
         //3
         module = new JBossModule('testModule-3')
@@ -366,9 +367,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    </native-artifact>\n" +
                 "  </resources>\n" +
                 "</module>"
-        assertEquals 'Case3:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case3:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Test
@@ -439,7 +440,7 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
         assertTrue new File([server.home, testM.path, 'slf4j-api-1.7.7.jar'].join(separator)).exists()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='org.slf4j'>\n" +
                 "  <resources>\n" +
                 "    <resource-root path='slf4j-api-1.7.7.jar' />\n" +
@@ -461,7 +462,7 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "<module xmlns='urn:jboss:module:" + getVersion().number + "' name='my.module'>\n" +
                 "  <dependencies />\n" +
                 "</module>"
-        assertEquals 'Case1:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
 
         // 2
@@ -530,9 +531,9 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "    </module>\n" +
                 "  </dependencies>\n" +
                 "</module>"
-        assertEquals 'Case2:', xml, module.moduleDescriptor
+        XMLUtil.assertXMLStrings 'Case2:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Test
@@ -562,7 +563,7 @@ class JBossModule1_9Test extends BasicJBossModuleTest {
                 "</module>"
         //assertEquals 'Case1:', xml, module.moduleDescriptor
         assertTrue module.valid
-        assertEquals 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
+        XMLUtil.assertXMLStrings 'Reverse:', xml, Ver.makeModule(xml).moduleDescriptor
     }
 
     @Override

--- a/src/test/groovy/com/github/zhurlik/extension/JBossServerTest.groovy
+++ b/src/test/groovy/com/github/zhurlik/extension/JBossServerTest.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.extension
 
+import TestUtils.XMLUtil
 import groovy.util.logging.Slf4j
 import org.junit.Test
 
@@ -55,7 +56,7 @@ class JBossServerTest {
         JBossModule jbModule = server.getModule('org.apache.xml-resolver')
         assertNotNull jbModule
         assertEquals 'org.apache.xml-resolver', jbModule.getModuleName()
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:1.1' name='org.apache.xml-resolver'>\n" +
                 "  <properties>\n" +
                 "    <property name='jboss.api' value='private' />\n" +

--- a/src/test/groovy/com/github/zhurlik/task/TasksTest.groovy
+++ b/src/test/groovy/com/github/zhurlik/task/TasksTest.groovy
@@ -1,5 +1,6 @@
 package com.github.zhurlik.task
 
+import TestUtils.XMLUtil
 import com.github.zhurlik.extension.JBossModule
 import com.github.zhurlik.extension.JBossServer
 import groovy.util.logging.Slf4j
@@ -104,7 +105,7 @@ class TasksTest {
         assertEquals 'org.slf4j', testM.name
         assertEquals 'org.slf4j', testM.moduleName
         assertEquals 'org.slf4j.impl', testM.dependencies[0].name
-        assertEquals "<?xml version='1.0' encoding='utf-8'?>\n" +
+        XMLUtil.assertXMLStrings "<?xml version='1.0' encoding='utf-8'?>\n" +
                 "<module xmlns='urn:jboss:module:" + V_1_3.number + "' name='org.slf4j'>\n" +
                 "  <dependencies>\n" +
                 "    <module name='org.slf4j.impl' />\n" +


### PR DESCRIPTION
This PR fixes flaky assertions in the following packages:
- com.github.zhurlik.descriptor
- com.github.zhurlik.extension
- com.github.zhurlik.task

The flaky tests have been found using the [NonDex](https://mvnrepository.com/artifact/edu.illinois/nondex-maven-plugin) tool.

## Problem:
XMLs are considered equal, even if the strings are not equal - for example, if the ordering of the elements on the same level or the order of the attributes in an element changes. The string comparison leads to a flaky test/assertion.

For example, the flakiness was discovered on the following lines
https://github.com/zhurlik/gradle-jboss-modules-plugin/blob/5f40cc05b0ffba0bf9e0a09026d7009f46cac023/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_0Test.groovy#L34-L35


## Solution:
To compare the XMLs, the strings are parsed and compared. By comparing the parsed elements, these classes take care of the changing order of elements and attributes. 
To create a reusable comparator, a static helper class was introduced to replace all XML assertions. 

For example:
https://github.com/zhurlik/gradle-jboss-modules-plugin/blob/1d5fb2eaa8267ac85beb4e504fd35db2ac3c37ef/src/test/groovy/com/github/zhurlik/descriptor/Xsd1_0Test.groovy#L34-L35


XMLUtil Comperator:
https://github.com/zhurlik/gradle-jboss-modules-plugin/blob/1d5fb2eaa8267ac85beb4e504fd35db2ac3c37ef/src/test/groovy/com/github/zhurlik/descriptor/XMLUtil.groovy#L5-L12

## Result:
The tests are deterministic and not flaky. This improves the quality of the tests and reduces the time to search for the bug during future development.

## Reproduce
To reproduce, follow the steps:

1. `./gradlew build -x test`
2. Add the following text to the top of the build.gradle file in $PROJ_DIR.
```shell
buildscript {
    repositories {
      maven {
        url = uri('https://plugins.gradle.org/m2/')
      }
    }
    dependencies {
      classpath('edu.illinois:plugin:2.1.1')
    }
}
``` 
3. Add the following line to the end of the build.gradle file in $PROJ_DIR.
```shell
apply plugin: 'edu.illinois.nondex'
``` 
4. Run
```shell
./gradlew nondexTest --tests=com.github.zhurlik.descriptor._testName_._test_ --info
``` 
